### PR TITLE
Add the summary report to tox pytest runs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ description =
 setenv =
     MPLBACKEND = agg
     COLUMNS = 180
-    PYTEST_COMMAND = pytest -vvv --pyargs sunpy --cov-report= --cov=sunpy --cov-config={toxinidir}/setup.cfg {toxinidir}/docs
+    PYTEST_COMMAND = pytest -vvv -ra --pyargs sunpy --cov-report= --cov=sunpy --cov-config={toxinidir}/setup.cfg {toxinidir}/docs
     devdeps,build_docs,online: HOME = {envtmpdir}
     SUNPY_SAMPLEDIR = {env:SUNPY_SAMPLEDIR:{toxinidir}/.tox/{envname}/sample_data/}
 passenv =


### PR DESCRIPTION
I like having it: https://docs.pytest.org/en/stable/usage.html#detailed-summary-report